### PR TITLE
Auto-Update Dockerfiles on new upstream releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile\\.(joex|restserver)$"],
+      "matchStrings": ["ARG DOCSPELL_VERSION=(?<currentValue>\\S+)"],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "eikek/docspell",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
   ]
 }


### PR DESCRIPTION
This change will automatically update the Docspell version via Renovate.