### PR TITLE
Change PostgreSQL data volume path in docker-compose

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -106,7 +106,7 @@ services:
     container_name: postgres_db
     restart: unless-stopped
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - postgres_data:/var/lib/postgresql/
     environment:
       POSTGRES_USER: 'dbuser'
       POSTGRES_PASSWORD: 'dbpass'


### PR DESCRIPTION
See: https://github.com/docker-library/postgres/issues/37

This volume path causes a clean install to be unable to start